### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Publish
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with: 
           registry: docker.pkg.github.com
           name: docker.pkg.github.com/kirill-samylin/MyTop


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore